### PR TITLE
Exit godopen --sync when buffer is deleted

### DIFF
--- a/godopen
+++ b/godopen
@@ -32,6 +32,10 @@ def _setup():
         nvim.command('tabnew {0}'.format(args.filename))
     else:
         nvim.command('e {0}'.format(args.filename))
+    _exit_when_deleted()
+
+def _exit_when_deleted():
+    nvim.command('autocmd BufDelete <buffer> call system("kill {0}")'.format(os.getpid()))
 
 def _stop(*args):
     nvim.stop_loop()


### PR DESCRIPTION
シェルの設定にこういう感じのものを仕込んでおいたときに
```zsh
if (( $+commands[godopen] )) && [[ -n "$NVIM_LISTEN_ADDRESS" ]]; then
    export GIT_EDITOR='godopen --sync --split'
fi
```
Neovim 内の `terminal` から `git commit` を叩くとターミナルのバッファーが `COMMIT_EDITMSG` の編集画面に切り替わって、そのバッファーを `:bd` したときにコミットが完了するので便利です。

`--sync` をつけないと `git` はエディターの終了を待たないのでコミットに失敗しますが、`--sync` をつけると `godopen` が終了するタイミングを失って `git` がそれを待ち続けるため、その対策が今回の PR です。